### PR TITLE
Enable string SSL configuration for xroad initializer

### DIFF
--- a/lib/x_road.rb
+++ b/lib/x_road.rb
@@ -21,8 +21,10 @@ module XRoad
 
   class Configuration
     attr_accessor :host
-    attr_accessor :client_cert
-    attr_accessor :client_key
+    attr_accessor :client_cert_file
+    attr_accessor :client_key_file
+    attr_accessor :client_cert_string
+    attr_accessor :client_key_string
     attr_accessor :log_level
     attr_accessor :ssl_verify
 

--- a/lib/x_road/active_x_road6.rb
+++ b/lib/x_road/active_x_road6.rb
@@ -75,8 +75,13 @@ module XRoad
         config = XRoad.configuration
         Savon.client do
           endpoint config.host
-          ssl_cert_file config.client_cert
-          ssl_cert_key_file config.client_key
+          if defined?(config.client_cert_file) && defined?(config.client_key_file)
+            ssl_cert_file config.client_cert_file
+            ssl_cert_key_file config.client_key_file
+          elsif defined?(config.client_cert_string) && defined?(config.client_key_string)
+            ssl_cert config.client_cert_string
+            ssl_cert_key config.client_key_string
+          end
           pretty_print_xml true
           ssl_verify_mode config.ssl_verify
           log true

--- a/lib/x_road/active_x_road6.rb
+++ b/lib/x_road/active_x_road6.rb
@@ -75,10 +75,10 @@ module XRoad
         config = XRoad.configuration
         Savon.client do
           endpoint config.host
-          if self.ssl_file_config?(config)
+          if defined?(config.client_cert_file) && defined?(config.client_key_file) && config.client_cert_file.present? && config.client_key_file.present?
             ssl_cert_file config.client_cert_file
             ssl_cert_key_file config.client_key_file
-          elsif self.ssl_string_config?(config)
+          elsif defined?(config.client_cert_string) && defined?(config.client_key_string) && config.client_cert_string.present? && config.client_key_string.present?
             ssl_cert config.client_cert_string
             ssl_cert_key config.client_key_string
           end
@@ -95,17 +95,6 @@ module XRoad
             'xmlns:SOAP-ENC': 'http://schemas.xmlsoap.org/soap/encoding/'
           )
         end
-      end
-
-
-      private
-
-      def ssl_file_config?(config)
-        defined?(config.client_cert_file) && defined?(config.client_key_file) && config.client_cert_file.present? && config.client_key_file.present?
-      end
-
-      def ssl_string_config?(config)
-        defined?(config.client_cert_string) && defined?(config.client_key_string) && config.client_cert_string.present? && config.client_key_string.present?
       end
     end
 

--- a/lib/x_road/active_x_road6.rb
+++ b/lib/x_road/active_x_road6.rb
@@ -75,10 +75,10 @@ module XRoad
         config = XRoad.configuration
         Savon.client do
           endpoint config.host
-          if defined?(config.client_cert_file) && defined?(config.client_key_file)
+          if ssl_file_config?(config)
             ssl_cert_file config.client_cert_file
             ssl_cert_key_file config.client_key_file
-          elsif defined?(config.client_cert_string) && defined?(config.client_key_string)
+          elsif ssl_string_config?(config)
             ssl_cert config.client_cert_string
             ssl_cert_key config.client_key_string
           end
@@ -95,6 +95,17 @@ module XRoad
             'xmlns:SOAP-ENC': 'http://schemas.xmlsoap.org/soap/encoding/'
           )
         end
+      end
+
+
+      private
+
+      def ssl_file_config?(config)
+        defined?(config.client_cert_file) && defined?(config.client_key_file) && config.client_cert_file.present? && config.client_key_file.present?
+      end
+
+      def ssl_string_config?(config)
+        defined?(config.client_cert_string) && defined?(config.client_key_string) && config.client_cert_string.present? && config.client_key_string.present?
       end
     end
 

--- a/lib/x_road/active_x_road6.rb
+++ b/lib/x_road/active_x_road6.rb
@@ -97,9 +97,6 @@ module XRoad
         end
       end
 
-
-      private
-
       def ssl_file_config?(config)
         defined?(config.client_cert_file) && defined?(config.client_key_file) && config.client_cert_file.present? && config.client_key_file.present?
       end

--- a/lib/x_road/active_x_road6.rb
+++ b/lib/x_road/active_x_road6.rb
@@ -75,10 +75,10 @@ module XRoad
         config = XRoad.configuration
         Savon.client do
           endpoint config.host
-          if ssl_file_config?(config)
+          if self.ssl_file_config?(config)
             ssl_cert_file config.client_cert_file
             ssl_cert_key_file config.client_key_file
-          elsif ssl_string_config?(config)
+          elsif self.ssl_string_config?(config)
             ssl_cert config.client_cert_string
             ssl_cert_key config.client_key_string
           end
@@ -96,6 +96,9 @@ module XRoad
           )
         end
       end
+
+
+      private
 
       def ssl_file_config?(config)
         defined?(config.client_cert_file) && defined?(config.client_key_file) && config.client_cert_file.present? && config.client_key_file.present?


### PR DESCRIPTION
For cloud infra providers like Heroku it is not possible to upload certificates and specially SSL keys into server securely and comfortably. Heroku uses env-variables configurable from their admin panel in browser. If now Rails uses values from there then they are not file-type as the xroad initializer atm expects for SSL client cert and key, instead they are String-type. This PR makes it possible to use string-type variables as well, **but for clarity it also renames previous variables with prefix '_file' to improve readability**.