### PR TITLE
Add proxy server configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ Gemfile.lock
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# Using byebug in dev-env results in the following file generated.
+# No need to have it in version control.
+.byebug_history

--- a/lib/x_road.rb
+++ b/lib/x_road.rb
@@ -12,9 +12,12 @@ module XRoad
     attr_writer :configuration
 
     def through_proxy?
-      configuration.proxy_address &&
-      configuration.proxy_username &&
-      configuration.proxy_password
+      # All of the following must be defined.
+      # If at least one of these is missing, then request
+      # will not be sent through the proxy server:
+      !(configuration.proxy_address.nil? ||
+      configuration.proxy_username.nil? ||
+      configuration.proxy_password.nil?)
     end
   end
 

--- a/lib/x_road.rb
+++ b/lib/x_road.rb
@@ -10,6 +10,12 @@ require 'x_road/services/tam.rb'
 module XRoad
   class << self
     attr_writer :configuration
+
+    def through_proxy?
+      configuration.proxy_address.present? &&
+      configuration.proxy_username.present? &&
+      configuration.proxy_password.present?
+    end
   end
 
   def self.configuration
@@ -33,6 +39,11 @@ module XRoad
     attr_accessor :client_member_code
     attr_accessor :client_subsystem_code
     attr_accessor :x_road_instance # by default client_path defines it
+
+    # Proxy-server scenario
+    attr_accessor :proxy_address
+    attr_accessor :proxy_username
+    attr_accessor :proxy_password
 
     def initialize
       @log_level = :info

--- a/lib/x_road.rb
+++ b/lib/x_road.rb
@@ -12,9 +12,9 @@ module XRoad
     attr_writer :configuration
 
     def through_proxy?
-      configuration.proxy_address.present? &&
-      configuration.proxy_username.present? &&
-      configuration.proxy_password.present?
+      configuration.proxy_address &&
+      configuration.proxy_username &&
+      configuration.proxy_password
     end
   end
 

--- a/lib/x_road/active_x_road6.rb
+++ b/lib/x_road/active_x_road6.rb
@@ -1,5 +1,3 @@
-require 'byebug'
-
 module XRoad
   class MissingXRoadHeadAttribute < ArgumentError; end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,5 +3,5 @@ Bundler.setup
 require 'x_road'
 
 RSpec.configure do |config|
-  config.expect_with(:rspec) { |c| c.syntax = :should }
+  config.expect_with(:rspec) { |c| c.syntax = :expect }
 end

--- a/spec/x_road_spec.rb
+++ b/spec/x_road_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe XRoad do
   context '#configure' do
     it 'has default values configured' do
-      XRoad.configuration.log_level.should == :info
+      expect(XRoad.configuration.log_level).to eql(:info)
     end
 
     it 'should populate all client path attributes' do
@@ -12,11 +12,43 @@ describe XRoad do
       end
 
       conf = XRoad.configuration
-      conf.x_road_instance.should == 'ee-test'
-      conf.client_x_road_instance.should == 'ee-test'
-      conf.client_member_class.should == 'NGO'
-      conf.client_member_code.should == '90005872'
-      conf.client_subsystem_code.should == 'harid'
+      expect(conf.x_road_instance).to eql('ee-test')
+      expect(conf.client_x_road_instance).to eql('ee-test')
+      expect(conf.client_member_class).to eql('NGO')
+      expect(conf.client_member_code).to eql('90005872')
+      expect(conf.client_subsystem_code).to eql('harid')
+    end
+  end
+
+  context 'With proxy-server' do
+    it 'knows by conf params if proxy needed' do
+      XRoad.configure do |config|
+        config.proxy_address = 'sth.sth.sth'
+        config.proxy_username = 'username'
+        config.proxy_password = 'pa55W0rd.'
+      end
+
+      expect(XRoad.through_proxy?).to be_truthy
+    end
+
+    it 'understands proxy not needed if all proxy conf params missing' do
+      XRoad.configure do |config|
+        config.proxy_address = nil
+        config.proxy_username = nil
+        config.proxy_password = nil
+      end
+
+      expect(XRoad.through_proxy?).to be_falsey
+    end
+
+    it 'understands proxy not needed if proxy conf params partially missing' do
+      XRoad.configure do |config|
+        config.proxy_address = nil
+        config.proxy_username = 'username'
+        config.proxy_password = 'pa55W0rd.'
+      end
+
+      expect(XRoad.through_proxy?).to be_falsey
     end
   end
 end

--- a/x_road.gemspec
+++ b/x_road.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'savon', '~> 2.11'
 
   spec.add_development_dependency "bundler"
+  spec.add_development_dependency 'byebug'
   spec.add_development_dependency "rake"
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'guard'


### PR DESCRIPTION
- This is needed to enable XRoad SOAP requests flow through a proxy server.

This usecase is happening for example when you have your application hosted in Heroku and you have attached QuotaGuard Shield proxy-server which enables you 2 static IPs. These IPs are whitelisted in XRoad security server and therefore all the XRoad SOAP requests must then flow through this proxy server.
Unfortunatelly it does not work automatically out of the box in Ruby- if you have a proxy server attached then not all requests automatically flow through proxy server. You need to define manually which requests are directed through it.


- Also this PR updates the RSpec specs to use newer `expect` syntax instead of `should` as is suggested by betterspecs here: https://www.betterspecs.org/#expect
- Add byebug gem as development dependency